### PR TITLE
Fix memory size for stm32f405rgtx, espruino not use ccmram (64k)

### DIFF
--- a/boards/ISKRAJS.py
+++ b/boards/ISKRAJS.py
@@ -51,7 +51,7 @@ chip = {
     'part' : "STM32F405RGT6",
     'family' : "STM32F4",
     'package' : "LQFP64",
-    'ram' : 192,
+    'ram' : 128,
     'flash' : 1024,
     'speed' : 168,
     'usart' : 6,

--- a/boards/ISKRAJS.py
+++ b/boards/ISKRAJS.py
@@ -20,7 +20,7 @@ info = {
     'link' :  [ "http://amperka.ru/product/iskra-js" ],
     'default_console' : "EV_SERIAL2",
     'default_busy_pin_indicator' : "B7",
-    'variables' : 5450,
+    'variables' : 7423, # (128-12)*1024/16-1
     'bootloader' : 1,
     'binary_name' : 'espruino_%v_iskrajs.bin',
     'images_url_base': 'http://js.amperka.ru/img/',


### PR DESCRIPTION
В даташите к STM32F405xx, сказано следующее: **Up to 192+4 Kbytes of SRAM including 64-Kbyte of CCM (core coupled memory) data RAM**. В Iskra JS используется STM32F405RG, у него 2 банка RAM по 112Кб и 16Кб, так же есть CCM RAM память, объемом 64Кб. Что-бы использовать CCM RAM, нужно отдельно описывать ее в скрипте для компоновщика, проект Espruino использует python скрипт для генерации скрипта для компоновщика, но данный python скрипт не поддерживает указание CCM RAM, да и сам интерпретатор тоже, если посмотреть на другие скрипты для плат, то можно заметить, что  размер памяти указан без CCM RAM. 

Получается прошивка с багом, если интерпретатор решит аллоцировать новую переменную за пределами размера в 128Кб, то произойдет HardFault ошибка, и дальнейшая нестабильность в работе.